### PR TITLE
Update BigInt formatter

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,8 +4,10 @@ const { ProviderWeb3 } = require('@vechain/web3-providers-connex');
 const { HDNode, Transaction, secp256k1, mnemonic} = require('thor-devkit');
 const fs = require('fs');
 
+const formatter = new Intl.NumberFormat('en-US', { useGrouping: false })
+
 BigInt.prototype['toJSON'] = function () {
-    return this.toLocaleString().replace(/"(-?\d+)n"/g, (_, a) => a);
+    return formatter.format(this);
 };
 
 function derivePrivateKeys(mnemonic, count)  {

--- a/index.js
+++ b/index.js
@@ -4,10 +4,8 @@ const { ProviderWeb3 } = require('@vechain/web3-providers-connex');
 const { HDNode, Transaction, secp256k1, mnemonic} = require('thor-devkit');
 const fs = require('fs');
 
-const formatter = new Intl.NumberFormat('en-US', { useGrouping: false })
-
 BigInt.prototype['toJSON'] = function () {
-    return formatter.format(this);
+    return this.toLocaleString('en-US', { useGrouping: false });
 };
 
 function derivePrivateKeys(mnemonic, count)  {


### PR DESCRIPTION
Update BigInt formatter in order to return a plain BigInt without the thousands separator in order to be compliant to the RPC-specification.
The chosen locale is `en-US` but since the value is a BigInt, its representation without the thousands separator will be the same for each and every locale.